### PR TITLE
output yaml instead of json on validation error

### DIFF
--- a/downloader.go
+++ b/downloader.go
@@ -1,7 +1,6 @@
 package bindown
 
 import (
-	"encoding/json"
 	"fmt"
 	"hash/fnv"
 	"io"
@@ -15,6 +14,7 @@ import (
 
 	"github.com/mholt/archiver/v3"
 	"github.com/willabides/bindown/v2/internal/util"
+	"gopkg.in/yaml.v2"
 )
 
 // Downloader downloads a binary
@@ -326,7 +326,7 @@ func (d *Downloader) Validate(opts ValidateOpts) error {
 		opts.CellarDir = filepath.Join(tmpDir, "cellar")
 	}
 
-	dlJSON, err := json.MarshalIndent(d, "", "  ")
+	dlYAML, err := yaml.Marshal(d)
 	if err != nil {
 		return err
 	}
@@ -340,7 +340,7 @@ func (d *Downloader) Validate(opts ValidateOpts) error {
 
 	err = d.Install(installOpts)
 	if err != nil {
-		return fmt.Errorf("could not validate downloader:\n%s", string(dlJSON))
+		return fmt.Errorf("could not validate downloader:\n%s", string(dlYAML))
 	}
 	return nil
 }


### PR DESCRIPTION
It used to output 

```
bindown: error: could not validate downloader:
                {
                  "os": "darwin",
                  "arch": "amd64",
                  "url": "https://github.com/golangci/golangci-lint/releases/download/v1.23.7/golangci-lint-1.23.7-darwin-amd64.tar.gz",
                  "checksum": "7536c375997cca3d2e1f063958ad0344108ce23aed6bd372b69153bdbda82d1",
                  "archive_path": "golangci-lint-1.23.7-darwin-amd64/golangci-lint",
                  "link": true
                }
```

Now it will output

```
bindown: error: could not validate downloader:
                os: darwin
                arch: amd64
                url: https://github.com/golangci/golangci-lint/releases/download/v1.23.7/golangci-lint-1.23.7-darwin-amd64.tar.gz
                checksum: 7536c375997cca3d2e1f063958ad0344108ce23aed6bd372b69153bdbda82d1
                archive_path: golangci-lint-1.23.7-darwin-amd64/golangci-lint
                link: true
```