### PR TITLE
remove support for move-from and symlink

### DIFF
--- a/downloader.go
+++ b/downloader.go
@@ -26,12 +26,6 @@ type Downloader struct {
 	ArchivePath string `json:"archive_path,omitempty" yaml:"archive_path,omitempty"`
 	Link        bool   `json:"link,omitempty" yaml:",omitempty"`
 	BinName     string `json:"bin,omitempty" yaml:"bin,omitempty"`
-
-	// Deprecated: use ArchivePath
-	MoveFrom string `json:"move-from,omitempty" yaml:"move-from,omitempty"`
-
-	// Deprecated: use ArchivePath and Link
-	LinkSource string `json:"symlink,omitempty" yaml:"symlink,omitempty"`
 }
 
 func (d *Downloader) downloadableName() (string, error) {
@@ -59,15 +53,6 @@ func (d *Downloader) chmod(targetDir string) error {
 }
 
 func (d *Downloader) moveOrLinkBin(targetDir, extractDir string) error {
-	//noinspection GoDeprecation
-	if d.LinkSource != "" {
-		d.ArchivePath = d.LinkSource
-		d.Link = true
-	}
-	//noinspection GoDeprecation
-	if d.MoveFrom != "" {
-		d.ArchivePath = d.MoveFrom
-	}
 	archivePath := filepath.FromSlash(d.ArchivePath)
 	if archivePath == "" {
 		archivePath = filepath.FromSlash(d.BinName)

--- a/downloader_test.go
+++ b/downloader_test.go
@@ -217,47 +217,7 @@ func TestDownloader_Install(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("legacy MoveFrom", func(t *testing.T) {
-		dir := testutil.TmpDir(t)
-		ts := testutil.ServeFile(t, testutil.DownloadablesPath("foo.tar.gz"), "/foo/foo.tar.gz", "foo=bar")
-		d := &Downloader{
-			URL:      ts.URL + "/foo/foo.tar.gz?foo=bar",
-			Checksum: testutil.FooChecksum,
-			BinName:  "foo.txt",
-			MoveFrom: "bin/foo.txt",
-			Arch:     "amd64",
-			OS:       "darwin",
-		}
-		err := d.Install(InstallOpts{
-			TargetDir: dir,
-			Force:     true,
-		})
-		assert.NoError(t, err)
-	})
-
 	t.Run("link", func(t *testing.T) {
-		dir := testutil.TmpDir(t)
-		ts := testutil.ServeFile(t, testutil.DownloadablesPath("foo.tar.gz"), "/foo/foo.tar.gz", "foo=bar")
-		d := &Downloader{
-			URL:        ts.URL + "/foo/foo.tar.gz?foo=bar",
-			Checksum:   testutil.FooChecksum,
-			BinName:    "foo",
-			LinkSource: "bin/foo.txt",
-			Arch:       "amd64",
-			OS:         "darwin",
-		}
-		err := d.Install(InstallOpts{
-			TargetDir: dir,
-			Force:     true,
-		})
-		assert.NoError(t, err)
-		linksTo, err := os.Readlink(filepath.Join(dir, "foo"))
-		assert.NoError(t, err)
-		absLinkTo := filepath.Join(dir, linksTo)
-		assert.True(t, fileExists(absLinkTo))
-	})
-
-	t.Run("legacy LinkSource", func(t *testing.T) {
 		dir := testutil.TmpDir(t)
 		ts := testutil.ServeFile(t, testutil.DownloadablesPath("foo.tar.gz"), "/foo/foo.tar.gz", "foo=bar")
 		d := &Downloader{


### PR DESCRIPTION
This is technically a breaking change, but I'm the only person who ever used this and I don't want to move to v3.