### PR TITLE
fix `bindown version`

### DIFF
--- a/cmd/bindown/main.go
+++ b/cmd/bindown/main.go
@@ -6,6 +6,11 @@ import (
 	"github.com/willabides/bindown/v2/internal/cli"
 )
 
+var version string
+
 func main() {
+	if version != "" {
+		cli.Version = version
+	}
 	cli.Run(os.Args[1:])
 }

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -4,11 +4,12 @@ import (
 	"github.com/alecthomas/kong"
 )
 
-var version = "unknown"
+//Version version to display for `bindown version`
+var Version = "unknown"
 
 type versionCmd struct{}
 
 func (*versionCmd) Run(k *kong.Context) error {
-	k.Printf("version %s", version)
+	k.Printf("version %s", Version)
 	return nil
 }


### PR DESCRIPTION
Release show "unknown" for the version since moving cli to internal