### PR TITLE
No error from hexHash

### DIFF
--- a/config.go
+++ b/config.go
@@ -340,21 +340,15 @@ type ConfigDownloadDependencyOpts struct {
 }
 
 // extractsCacheDir returns the cache directory for an extraction based on the download's checksum and dependency name
-func (c *Config) extractsCacheDir(dependencyName, checksum string) (string, error) {
-	hsh, err := hexHash(fnv.New64a(), []byte(checksum))
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(c.Cache, "extracts", hsh), nil
+func (c *Config) extractsCacheDir(hashMaterial string) string {
+	hsh := hexHash(fnv.New64a(), []byte(hashMaterial))
+	return filepath.Join(c.Cache, "extracts", hsh)
 }
 
 // downloadCacheDir returns the cache directory for a file based on its checksum
-func (c *Config) downloadCacheDir(checksum string) (string, error) {
-	hsh, err := hexHash(fnv.New64a(), []byte(checksum))
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(c.Cache, "downloads", hsh), nil
+func (c *Config) downloadCacheDir(hashMaterial string) string {
+	hsh := hexHash(fnv.New64a(), []byte(hashMaterial))
+	return filepath.Join(c.Cache, "downloads", hsh)
 }
 
 // DownloadDependency downloads a dependency
@@ -397,15 +391,12 @@ func (c *Config) DownloadDependency(dependencyName string, sysInfo SystemInfo, o
 	}
 
 	if targetFile == "" {
-		var dlFile, cacheDir string
+		var dlFile string
 		dlFile, err = urlFilename(depURL)
 		if err != nil {
 			return "", err
 		}
-		cacheDir, err = c.downloadCacheDir(checksum)
-		if err != nil {
-			return "", err
-		}
+		cacheDir := c.downloadCacheDir(checksum)
 		targetFile = filepath.Join(cacheDir, dlFile)
 	}
 
@@ -508,7 +499,7 @@ func (c *Config) ExtractDependency(dependencyName string, sysInfo SystemInfo, op
 				return "", err
 			}
 		}
-		targetDir, err = c.extractsCacheDir(dependencyName, checksum)
+		targetDir = c.extractsCacheDir(checksum)
 		if err != nil {
 			return "", err
 		}

--- a/util.go
+++ b/util.go
@@ -102,16 +102,17 @@ func directoryChecksum(inputDir string) (string, error) {
 }
 
 // hexHash returns a hex representation of data's hash
-// This will only return non-nil error if given a hasher that can return a non-nil error from Write()
-func hexHash(hasher hash.Hash, data ...[]byte) (string, error) {
+func hexHash(hasher hash.Hash, data ...[]byte) string {
 	hasher.Reset()
 	for _, datum := range data {
 		_, err := hasher.Write(datum)
 		if err != nil {
-			return "", err
+			// hash.Hash.Write() never returns an error
+			// https://github.com/golang/go/blob/go1.17/src/hash/hash.go#L27-L29
+			panic(err)
 		}
 	}
-	return hex.EncodeToString(hasher.Sum(nil)), nil
+	return hex.EncodeToString(hasher.Sum(nil))
 }
 
 // fileChecksum returns the hex checksum of a file
@@ -120,7 +121,7 @@ func fileChecksum(filename string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return hexHash(sha256.New(), fileBytes)
+	return hexHash(sha256.New(), fileBytes), nil
 }
 
 // fileExists asserts that a file exists

--- a/util_test.go
+++ b/util_test.go
@@ -73,17 +73,11 @@ func Test_fileChecksum(t *testing.T) {
 }
 
 func Test_hexHash(t *testing.T) {
-	got, err := hexHash(fnv.New64a(), []byte("foo"))
-	require.NoError(t, err)
-	require.Equal(t, "dcb27518fed9d577", got)
-	got, err = hexHash(fnv.New64a(), []byte("foo"), []byte("bar"))
-	require.NoError(t, err)
-	require.Equal(t, "85944171f73967e8", got)
+	require.Equal(t, "dcb27518fed9d577", hexHash(fnv.New64a(), []byte("foo")))
+	require.Equal(t, "85944171f73967e8", hexHash(fnv.New64a(), []byte("foo"), []byte("bar")))
 	content, err := os.ReadFile(filepath.Join("testdata", "downloadables", "foo.tar.gz"))
 	require.NoError(t, err)
-	got, err = hexHash(sha256.New(), content)
-	require.NoError(t, err)
-	require.Equal(t, fooChecksum, got)
+	require.Equal(t, fooChecksum, hexHash(sha256.New(), content))
 }
 
 func Test_copyFile(t *testing.T) {


### PR DESCRIPTION
hash.Write() never returns an error, so we don't need to return an error from hexHash