### PR TITLE
Allow trusting the cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,8 @@ Flags:
                              bindown.yaml, bindown.json, .bindown.yml, .bindown.yaml or
                              .bindown.json ($BINDOWN_CONFIG_FILE)
       --cache=STRING         directory downloads will be cached ($BINDOWN_CACHE)
+      --trust-cache          trust the cache contents and do not recheck existing downloads and
+                             extracts in the cache ($BINDOWN_TRUST_CACHE)
   -q, --quiet                suppress output to stdout
 
 Commands:

--- a/README.md
+++ b/README.md
@@ -294,15 +294,15 @@ overrides:
 Usage: bindown <command>
 
 Flags:
-  -h, --help                 Show context-sensitive help.
-      --json                 treat config file as json instead of yaml
-      --configfile=STRING    file with bindown config. default is the first one of bindown.yml,
-                             bindown.yaml, bindown.json, .bindown.yml, .bindown.yaml or
-                             .bindown.json ($BINDOWN_CONFIG_FILE)
-      --cache=STRING         directory downloads will be cached ($BINDOWN_CACHE)
-      --trust-cache          trust the cache contents and do not recheck existing downloads and
-                             extracts in the cache ($BINDOWN_TRUST_CACHE)
-  -q, --quiet                suppress output to stdout
+  -h, --help                       Show context-sensitive help.
+      --json                       treat config file as json instead of yaml
+      --configfile=STRING          file with bindown config. default is the first one of
+                                   bindown.yml, bindown.yaml, bindown.json, .bindown.yml,
+                                   .bindown.yaml or .bindown.json ($BINDOWN_CONFIG_FILE)
+      --cache=STRING               directory downloads will be cached ($BINDOWN_CACHE)
+      --trust-cache=TRUST-CACHE    trust the cache contents and do not recheck existing downloads
+                                   and extracts in the cache ($BINDOWN_TRUST_CACHE)
+  -q, --quiet                      suppress output to stdout
 
 Commands:
   download                       download a dependency but don't extract or install it

--- a/bindown.schema.json
+++ b/bindown.schema.json
@@ -60,7 +60,7 @@
           "type": "array"
         },
         "template": {
-          "description": "A template for this dependency. Any unset fields in this dependency will be set by values from the template. Overrides in the dependency and its template are concatinated with the template's overrides coming first. Vars and substitutions are both combined with the dependency's value taking precedence.\n",
+          "description": "A template for this dependency. Any unset fields in this dependency will be set by values from the template. Overrides in the dependency and its template are concatenated with the template's overrides coming first. Vars and substitutions are both combined with the dependency's value taking precedence.\n",
           "type": "string"
         },
         "url": {
@@ -164,6 +164,11 @@
       },
       "description": "Templates that can be used by dependencies in this file.",
       "type": "object"
+    },
+    "trust_cache": {
+      "default": false,
+      "description": "If true, bindown will trust the contents of the cache and not recheck checksums or verify that the files in the cache are the same as the files that were downloaded.\n",
+      "type": "boolean"
     },
     "url_checksums": {
       "additionalProperties": {

--- a/bindown.schema.yml
+++ b/bindown.schema.yml
@@ -9,7 +9,7 @@ $defs:
       template:
         description: >
           A template for this dependency. Any unset fields in this dependency will be set by values from the template.
-          Overrides in the dependency and its template are concatinated with the template's overrides coming first.
+          Overrides in the dependency and its template are concatenated with the template's overrides coming first.
           Vars and substitutions are both combined with the dependency's value taking precedence.
         type: string
       url:
@@ -106,6 +106,12 @@ properties:
       operating systems where the native delimiter isn't /.
     default: ./.bindown
     type: string
+  trust_cache:
+    description: >
+      If true, bindown will trust the contents of the cache and not recheck checksums or verify that the files in the
+      cache are the same as the files that were downloaded.
+    default: false
+    type: boolean
   install_directory:
     description: >
       The directory that bindown installs files to. This is relative to the directory where the configuration file

--- a/bindown.yml
+++ b/bindown.yml
@@ -1,4 +1,5 @@
 cache: ./bin/.bindown
+trust_cache: true
 install_dir: ./bin
 systems:
 - darwin/amd64

--- a/cmd/bindown/cli.go
+++ b/cmd/bindown/cli.go
@@ -42,12 +42,14 @@ var kongVars = kong.Vars{
 	"extract_help":                    `download and extract a dependency but don't install it`,
 	"extract_target_dir_help":         `path to extract to. Default extracts to cache.`,
 	"checksums_dep_help":              `name of the dependency to update`,
+	"trust_cache_help":                `trust the cache contents and do not recheck existing downloads and extracts in the cache`,
 }
 
 var cli struct {
 	JSONConfig bool   `kong:"name=json,help='treat config file as json instead of yaml'"`
 	Configfile string `kong:"type=path,help=${configfile_help},env='BINDOWN_CONFIG_FILE'"`
 	Cache      string `kong:"type=path,help=${cache_help},env='BINDOWN_CACHE'"`
+	TrustCache bool   `kong:"help=${trust_cache_help},env='BINDOWN_TRUST_CACHE'"`
 	Quiet      bool   `kong:"short='q',help='suppress output to stdout'"`
 
 	Download        downloadCmd        `kong:"cmd,help=${download_help}"`
@@ -95,6 +97,9 @@ func (d defaultConfigLoader) Load(ctx context.Context, filename string, noDefaul
 	}
 	if cli.Cache != "" {
 		configFile.Cache = cli.Cache
+	}
+	if cli.TrustCache {
+		configFile.TrustCache = true
 	}
 	return configFile, nil
 }

--- a/cmd/bindown/cli.go
+++ b/cmd/bindown/cli.go
@@ -49,7 +49,7 @@ var cli struct {
 	JSONConfig bool   `kong:"name=json,help='treat config file as json instead of yaml'"`
 	Configfile string `kong:"type=path,help=${configfile_help},env='BINDOWN_CONFIG_FILE'"`
 	Cache      string `kong:"type=path,help=${cache_help},env='BINDOWN_CACHE'"`
-	TrustCache bool   `kong:"help=${trust_cache_help},env='BINDOWN_TRUST_CACHE'"`
+	TrustCache *bool  `kong:"help=${trust_cache_help},env='BINDOWN_TRUST_CACHE'"`
 	Quiet      bool   `kong:"short='q',help='suppress output to stdout'"`
 
 	Download        downloadCmd        `kong:"cmd,help=${download_help}"`
@@ -98,8 +98,8 @@ func (d defaultConfigLoader) Load(ctx context.Context, filename string, noDefaul
 	if cli.Cache != "" {
 		configFile.Cache = cli.Cache
 	}
-	if cli.TrustCache {
-		configFile.TrustCache = true
+	if cli.TrustCache != nil {
+		configFile.TrustCache = *cli.TrustCache
 	}
 	return configFile, nil
 }

--- a/config.go
+++ b/config.go
@@ -397,14 +397,14 @@ func (c *Config) DownloadDependency(dependencyName string, sysInfo SystemInfo, o
 		}
 		cacheDir := c.downloadCacheDir(checksum)
 		targetFile = filepath.Join(cacheDir, dlFile)
+
+		if c.TrustCache && !opts.Force && fileExists(targetFile) {
+			return targetFile, nil
+		}
 	}
 
 	if !downloadedToTemp {
 		return targetFile, download(depURL, targetFile, checksum, opts.Force)
-	}
-
-	if c.TrustCache && !opts.Force && fileExists(targetFile) {
-		return targetFile, nil
 	}
 
 	ok, err := fileExistsWithChecksum(targetFile, checksum)

--- a/config.go
+++ b/config.go
@@ -20,6 +20,7 @@ import (
 // Config is our main config
 type Config struct {
 	Cache           string                 `json:"cache,omitempty" yaml:"cache,omitempty"`
+	TrustCache      bool                   `json:"trust_cache,omitempty" yaml:"trust_cache,omitempty"`
 	InstallDir      string                 `json:"install_dir,omitempty" yaml:"install_dir,omitempty"`
 	Systems         []SystemInfo           `json:"systems,omitempty" yaml:"systems,omitempty"`
 	Dependencies    map[string]*Dependency `json:"dependencies,omitempty" yaml:",omitempty"`

--- a/config.go
+++ b/config.go
@@ -403,6 +403,10 @@ func (c *Config) DownloadDependency(dependencyName string, sysInfo SystemInfo, o
 		return targetFile, download(depURL, targetFile, checksum, opts.Force)
 	}
 
+	if c.TrustCache && !opts.Force && fileExists(targetFile) {
+		return targetFile, nil
+	}
+
 	ok, err := fileExistsWithChecksum(targetFile, checksum)
 	if err != nil {
 		return "", err
@@ -499,8 +503,8 @@ func (c *Config) ExtractDependency(dependencyName string, sysInfo SystemInfo, op
 			}
 		}
 		targetDir = c.extractsCacheDir(checksum)
-		if err != nil {
-			return "", err
+		if c.TrustCache && !opts.Force && fileExists(targetDir) {
+			return targetDir, nil
 		}
 	}
 	dlFile, err := urlFilename(*dep.URL)

--- a/docs/clihelp.txt
+++ b/docs/clihelp.txt
@@ -1,15 +1,15 @@
 Usage: bindown <command>
 
 Flags:
-  -h, --help                 Show context-sensitive help.
-      --json                 treat config file as json instead of yaml
-      --configfile=STRING    file with bindown config. default is the first one of bindown.yml,
-                             bindown.yaml, bindown.json, .bindown.yml, .bindown.yaml or
-                             .bindown.json ($BINDOWN_CONFIG_FILE)
-      --cache=STRING         directory downloads will be cached ($BINDOWN_CACHE)
-      --trust-cache          trust the cache contents and do not recheck existing downloads and
-                             extracts in the cache ($BINDOWN_TRUST_CACHE)
-  -q, --quiet                suppress output to stdout
+  -h, --help                       Show context-sensitive help.
+      --json                       treat config file as json instead of yaml
+      --configfile=STRING          file with bindown config. default is the first one of
+                                   bindown.yml, bindown.yaml, bindown.json, .bindown.yml,
+                                   .bindown.yaml or .bindown.json ($BINDOWN_CONFIG_FILE)
+      --cache=STRING               directory downloads will be cached ($BINDOWN_CACHE)
+      --trust-cache=TRUST-CACHE    trust the cache contents and do not recheck existing downloads
+                                   and extracts in the cache ($BINDOWN_TRUST_CACHE)
+  -q, --quiet                      suppress output to stdout
 
 Commands:
   download                       download a dependency but don't extract or install it

--- a/docs/clihelp.txt
+++ b/docs/clihelp.txt
@@ -7,6 +7,8 @@ Flags:
                              bindown.yaml, bindown.json, .bindown.yml, .bindown.yaml or
                              .bindown.json ($BINDOWN_CONFIG_FILE)
       --cache=STRING         directory downloads will be cached ($BINDOWN_CACHE)
+      --trust-cache          trust the cache contents and do not recheck existing downloads and
+                             extracts in the cache ($BINDOWN_TRUST_CACHE)
   -q, --quiet                suppress output to stdout
 
 Commands:

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
-	github.com/alecthomas/kong v0.2.22
+	github.com/alecthomas/kong v0.7.1
 	github.com/ghodss/yaml v1.0.0
 	github.com/golang/mock v1.6.0
 	github.com/google/go-cmp v0.5.8

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,9 @@
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
-github.com/alecthomas/kong v0.2.22 h1:lRcQYT2/yJ+coDNA5ws0mRL0pwSqjbP/6AcRkyKhomk=
-github.com/alecthomas/kong v0.2.22/go.mod h1:uzxf/HUh0tj43x1AyJROl3JT7SgsZ5m+icOv1csRhc0=
-github.com/alecthomas/repr v0.0.0-20210801044451-80ca428c5142 h1:8Uy0oSf5co/NZXje7U1z8Mpep++QJOldL2hs/sBQf48=
-github.com/alecthomas/repr v0.0.0-20210801044451-80ca428c5142/go.mod h1:2kn6fqh/zIyPLmm3ugklbEi5hg5wS435eygvNfaDQL8=
+github.com/alecthomas/assert/v2 v2.1.0 h1:tbredtNcQnoSd3QBhQWI7QZ3XHOVkw1Moklp2ojoH/0=
+github.com/alecthomas/kong v0.7.1 h1:azoTh0IOfwlAX3qN9sHWTxACE2oV8Bg2gAwBsMwDQY4=
+github.com/alecthomas/kong v0.7.1/go.mod h1:n1iCIO2xS46oE8ZfYCNDqdR0b0wZNrXAIAqro/2132U=
+github.com/alecthomas/repr v0.1.0 h1:ENn2e1+J3k09gyj2shc0dHr/yjaWSHRlrJ4DPMevDqE=
 github.com/andybalholm/brotli v1.0.1/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/andybalholm/brotli v1.0.4 h1:V7DdXeJtZscaqfNuAdSRuRFzuiKlHSC/Zh3zl9qY3JY=
 github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
@@ -29,6 +29,7 @@ github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
+github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.11.4/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.13.6 h1:P76CopJELS0TiO2mebmnzgWaajssP/EszplttgQxcgc=


### PR DESCRIPTION
Adds `--trust-cache` command line option, `BINDOWN_TRUST_CACHE` environment variable and `trust_cache` config file option.