### PR TITLE
file-locking cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        platform: [ ubuntu-20.04, macos-11 ]
+        platform: [ ubuntu-20.04, macos-11, windows-2019 ]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v3

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,11 +22,20 @@ linters:
     - gofumpt
     - revive
 linters-settings:
+  gosec:
+    excludes:
+      - G204 # Subprocess launched with variable
+      - G301 # Expect directory permissions to be 0750 or less
+      - G302 # Expect file permissions to be 0600 or less
+      - G306 # Expect WriteFile permissions to be 0600 or less
   gocritic:
     enabled-tags:
       - style
       - diagnostic
       - performance
+    disabled-checks:
+      - rangeValCopy
+      - ptrToRefParam
   errcheck:
     # report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`;
     # default is false: such cases aren't reported by default.

--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ Commands:
   checksums add                  add checksums to the config file
   checksums prune                remove unnecessary checksums from the config file
   init                           create an empty config file
+  cache clear                    clear the cache
   version                        show bindown version
   install-completions            install shell completions
 

--- a/cmd/bindown/cache.go
+++ b/cmd/bindown/cache.go
@@ -7,7 +7,7 @@ type cacheCmd struct {
 type cacheClearCmd struct{}
 
 func (c *cacheClearCmd) Run(ctx *runContext) error {
-	config, err := loadConfigFile(ctx, true)
+	config, err := loadConfigFile(ctx, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/bindown/cache.go
+++ b/cmd/bindown/cache.go
@@ -1,0 +1,15 @@
+package main
+
+type cacheCmd struct {
+	Clear cacheClearCmd `kong:"cmd,help='clear the cache'"`
+}
+
+type cacheClearCmd struct{}
+
+func (c *cacheClearCmd) Run(ctx *runContext) error {
+	config, err := loadConfigFile(ctx, true)
+	if err != nil {
+		return err
+	}
+	return config.ClearCache()
+}

--- a/cmd/bindown/cache_test.go
+++ b/cmd/bindown/cache_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/willabides/bindown/v3"
+)
+
+func Test_cacheClearCmd(t *testing.T) {
+	servePath := filepath.FromSlash("../../testdata/downloadables/fooinroot.tar.gz")
+	successServer := serveFile(t, servePath, "/foo/fooinroot.tar.gz", "")
+	depURL := successServer.URL + "/foo/fooinroot.tar.gz"
+
+	t.Run("removes populated cache", func(t *testing.T) {
+		runner := newCmdRunner(t)
+		// extract something to populate the cache
+		runner.writeConfig(&bindown.Config{
+			URLChecksums: map[string]string{
+				depURL: "27dcce60d1ed72920a84dd4bc01e0bbd013e5a841660e9ee2e964e53fb83c0b3",
+			},
+			Dependencies: map[string]*bindown.Dependency{
+				"foo": {URL: &depURL},
+			},
+		})
+		result := runner.run("extract", "foo")
+		extractDir := result.getExtractDir()
+		assert.FileExists(t, filepath.Join(extractDir, "foo"))
+		result = runner.run("cache", "clear")
+		result.assertState(resultState{})
+		assert.NoDirExists(t, extractDir)
+	})
+
+	t.Run("does nothing if cache is empty", func(t *testing.T) {
+		runner := newCmdRunner(t)
+		runner.writeConfig(&bindown.Config{})
+		result := runner.run("cache", "clear")
+		result.assertState(resultState{})
+	})
+
+	t.Run("errors on missing config", func(t *testing.T) {
+		runner := newCmdRunner(t)
+		result := runner.run("cache", "clear")
+		result.assertState(resultState{
+			exit:   1,
+			stderr: `no such file or directory`,
+		})
+	})
+}

--- a/cmd/bindown/cli.go
+++ b/cmd/bindown/cli.go
@@ -44,7 +44,7 @@ var kongVars = kong.Vars{
 type rootCmd struct {
 	JSONConfig bool   `kong:"name=json,help='treat config file as json instead of yaml'"`
 	Configfile string `kong:"type=path,help=${configfile_help},env='BINDOWN_CONFIG_FILE'"`
-	Cache      string `kong:"type=path,help=${cache_help},env='BINDOWN_CACHE'"`
+	CacheDir   string `kong:"name=cache,type=path,help=${cache_help},env='BINDOWN_CACHE'"`
 	TrustCache *bool  `kong:"help=${trust_cache_help},env='BINDOWN_TRUST_CACHE'"`
 	Quiet      bool   `kong:"short='q',help='suppress output to stdout'"`
 
@@ -58,6 +58,7 @@ type rootCmd struct {
 	SupportedSystem supportedSystemCmd `kong:"cmd,help='manage supported systems'"`
 	Checksums       checksumsCmd       `kong:"cmd,help='manage checksums'"`
 	Init            initCmd            `kong:"cmd,help='create an empty config file'"`
+	Cache           cacheCmd           `kong:"cmd,help='manage the cache'"`
 
 	Version            versionCmd                   `kong:"cmd,help='show bindown version'"`
 	InstallCompletions kongplete.InstallCompletions `kong:"cmd,help=${config_install_completions_help}"`
@@ -90,8 +91,8 @@ func loadConfigFile(ctx *runContext, noDefaultDirs bool) (*bindown.ConfigFile, e
 	if err != nil {
 		return nil, err
 	}
-	if ctx.rootCmd.Cache != "" {
-		configFile.Cache = ctx.rootCmd.Cache
+	if ctx.rootCmd.CacheDir != "" {
+		configFile.Cache = ctx.rootCmd.CacheDir
 	}
 	if ctx.rootCmd.TrustCache != nil {
 		configFile.TrustCache = *ctx.rootCmd.TrustCache
@@ -228,7 +229,7 @@ func (c *initCmd) Run(ctx *runContext) error {
 type fmtCmd struct{}
 
 func (c fmtCmd) Run(ctx *runContext, cli *rootCmd) error {
-	ctx.rootCmd.Cache = ""
+	ctx.rootCmd.CacheDir = ""
 	config, err := loadConfigFile(ctx, true)
 	if err != nil {
 		return err

--- a/cmd/bindown/cli_test.go
+++ b/cmd/bindown/cli_test.go
@@ -256,7 +256,6 @@ func Test_extractCmd(t *testing.T) {
 }
 
 func Test_downloadCmd(t *testing.T) {
-	t.Parallel()
 	servePath := filepath.FromSlash("../../testdata/downloadables/fooinroot.tar.gz")
 	successServer := serveFile(t, servePath, "/foo/fooinroot.tar.gz", "")
 	depURL := successServer.URL + "/foo/fooinroot.tar.gz"

--- a/cmd/bindown/cli_test.go
+++ b/cmd/bindown/cli_test.go
@@ -134,11 +134,27 @@ func Test_initCmd(t *testing.T) {
 }
 
 func Test_extractCmd(t *testing.T) {
+	servePath := filepath.FromSlash("../../testdata/downloadables/fooinroot.tar.gz")
+	successServer := serveFile(t, servePath, "/foo/fooinroot.tar.gz", "")
+	depURL := successServer.URL + "/foo/fooinroot.tar.gz"
+
+	assertExtractSuccess := func(t *testing.T, result *runCmdResult) {
+		t.Helper()
+		prefix := "extracted foo to "
+		result.assertState(resultState{
+			stdout: prefix,
+		})
+		extractDir := result.getExtractDir()
+		wantFile := filepath.Join(extractDir, "foo")
+		require.FileExists(t, wantFile)
+		// make sure there are no extra files
+		dirFiles, err := os.ReadDir(extractDir)
+		require.NoError(t, err)
+		require.Len(t, dirFiles, 1)
+	}
+
 	t.Run("success", func(t *testing.T) {
 		runner := newCmdRunner(t)
-		servePath := filepath.FromSlash("../../testdata/downloadables/fooinroot.tar.gz")
-		ts := serveFile(t, servePath, "/foo/fooinroot.tar.gz", "")
-		depURL := ts.URL + "/foo/fooinroot.tar.gz"
 		runner.writeConfig(&bindown.Config{
 			URLChecksums: map[string]string{
 				depURL: "27dcce60d1ed72920a84dd4bc01e0bbd013e5a841660e9ee2e964e53fb83c0b3",
@@ -150,17 +166,97 @@ func Test_extractCmd(t *testing.T) {
 			},
 		})
 		result := runner.run("extract", "foo")
-		require.Equal(t, 0, result.exitVal)
-		stdout := result.stdOut.String()
-		wantPrefix := "extracted foo to "
-		require.True(t, strings.HasPrefix(stdout, wantPrefix))
-		extractDir := strings.TrimSpace(strings.TrimPrefix(stdout, wantPrefix))
-		wantFile := filepath.Join(extractDir, "foo")
-		require.FileExists(t, wantFile)
+		assertExtractSuccess(t, result)
+	})
+
+	t.Run("invalid cache", func(t *testing.T) {
+		runner := newCmdRunner(t)
+		runner.writeConfig(&bindown.Config{
+			URLChecksums: map[string]string{
+				depURL: "27dcce60d1ed72920a84dd4bc01e0bbd013e5a841660e9ee2e964e53fb83c0b3",
+			},
+			Dependencies: map[string]*bindown.Dependency{
+				"foo": {
+					URL: &depURL,
+				},
+			},
+		})
+		result := runner.run("extract", "foo")
+		assertExtractSuccess(t, result)
+		extractDir := result.getExtractDir()
+		unsealDir(t, extractDir)
+		err := os.WriteFile(filepath.Join(extractDir, "foo"), []byte("foo"), 0o666)
+		require.NoError(t, err)
+		result = runner.run("extract", "foo")
+		assertExtractSuccess(t, result)
+	})
+
+	t.Run("--trust-cache with empty cache", func(t *testing.T) {
+		runner := newCmdRunner(t)
+		runner.writeConfig(&bindown.Config{
+			URLChecksums: map[string]string{
+				depURL: "27dcce60d1ed72920a84dd4bc01e0bbd013e5a841660e9ee2e964e53fb83c0b3",
+			},
+			Dependencies: map[string]*bindown.Dependency{
+				"foo": {
+					URL: &depURL,
+				},
+			},
+		})
+		result := runner.run("extract", "foo", "--trust-cache")
+		assertExtractSuccess(t, result)
+	})
+
+	t.Run("--trust-cache with valid cache", func(t *testing.T) {
+		runner := newCmdRunner(t)
+		runner.writeConfig(&bindown.Config{
+			URLChecksums: map[string]string{
+				depURL: "27dcce60d1ed72920a84dd4bc01e0bbd013e5a841660e9ee2e964e53fb83c0b3",
+			},
+			Dependencies: map[string]*bindown.Dependency{
+				"foo": {
+					URL: &depURL,
+				},
+			},
+		})
+		result := runner.run("extract", "foo")
+		assertExtractSuccess(t, result)
+		result = runner.run("extract", "foo", "--trust-cache")
+		assertExtractSuccess(t, result)
+	})
+
+	t.Run("--trust-cache does not overwrite invalid cache", func(t *testing.T) {
+		runner := newCmdRunner(t)
+		runner.writeConfig(&bindown.Config{
+			URLChecksums: map[string]string{
+				depURL: "27dcce60d1ed72920a84dd4bc01e0bbd013e5a841660e9ee2e964e53fb83c0b3",
+			},
+			Dependencies: map[string]*bindown.Dependency{
+				"foo": {
+					URL: &depURL,
+				},
+			},
+		})
+		result := runner.run("extract", "foo")
+		assertExtractSuccess(t, result)
+		extractDir := result.getExtractDir()
+		extractedFile := filepath.Join(extractDir, "foo")
+		unsealDir(t, extractDir)
+		err := os.WriteFile(extractedFile, []byte("foo"), 0o666)
+		require.NoError(t, err)
+		result = runner.run("extract", "foo", "--trust-cache")
+		result.assertState(resultState{
+			stdout: "extracted foo to ",
+		})
+		// make sure the file was not overwritten
+		got, err := os.ReadFile(extractedFile)
+		require.NoError(t, err)
+		assert.Equal(t, "foo", string(got))
 	})
 }
 
 func Test_downloadCmd(t *testing.T) {
+	t.Parallel()
 	servePath := filepath.FromSlash("../../testdata/downloadables/fooinroot.tar.gz")
 	successServer := serveFile(t, servePath, "/foo/fooinroot.tar.gz", "")
 	depURL := successServer.URL + "/foo/fooinroot.tar.gz"
@@ -198,6 +294,23 @@ func Test_downloadCmd(t *testing.T) {
 		assertDownloadSuccess(t, result)
 	})
 
+	t.Run("--output", func(t *testing.T) {
+		runner := newCmdRunner(t)
+		outFile := filepath.Join(runner.tmpDir, "out", "foo.tar.gz")
+		runner.writeConfig(&bindown.Config{
+			URLChecksums: map[string]string{
+				depURL: "27dcce60d1ed72920a84dd4bc01e0bbd013e5a841660e9ee2e964e53fb83c0b3",
+			},
+			Dependencies: map[string]*bindown.Dependency{
+				"foo": {
+					URL: &depURL,
+				},
+			},
+		})
+		result := runner.run("download", "foo", "--output", outFile)
+		assertDownloadSuccess(t, result)
+	})
+
 	t.Run("no url", func(t *testing.T) {
 		runner := newCmdRunner(t)
 		runner.writeConfig(&bindown.Config{
@@ -207,7 +320,7 @@ func Test_downloadCmd(t *testing.T) {
 		})
 		result := runner.run("download", "foo")
 		result.assertState(resultState{
-			stderr: `cmd: error: no URL configured`,
+			stderr: `cmd: error: dependency "foo" has no URL`,
 			exit:   1,
 		})
 	})
@@ -239,7 +352,7 @@ func Test_downloadCmd(t *testing.T) {
 		})
 		result := runner.run("download", "foo")
 		result.assertState(resultState{
-			stderr: `cmd: error: no checksum for the url`,
+			stderr: `cmd: error: no checksum configured for foo`,
 			exit:   1,
 		})
 	})
@@ -309,6 +422,23 @@ func Test_downloadCmd(t *testing.T) {
 		result = runner.run("download", "foo", "--allow-missing-checksum")
 		assertDownloadSuccess(t, result)
 	})
+
+	t.Run("already exists with --allow-missing-checksum --trust-cache", func(t *testing.T) {
+		runner := newCmdRunner(t)
+		runner.writeConfig(&bindown.Config{
+			Dependencies: map[string]*bindown.Dependency{
+				"foo": {
+					URL: &depURL,
+				},
+			},
+		})
+		// download to put it in the cache
+		result := runner.run("download", "foo", "--allow-missing-checksum", "--trust-cache")
+		assertDownloadSuccess(t, result)
+		// download again
+		result = runner.run("download", "foo", "--allow-missing-checksum", "--trust-cache")
+		assertDownloadSuccess(t, result)
+	})
 }
 
 func Test_installCmd(t *testing.T) {
@@ -334,6 +464,32 @@ func Test_installCmd(t *testing.T) {
 		stat, err := os.Stat(wantBin)
 		require.NoError(t, err)
 		require.EqualValues(t, os.FileMode(0o750), stat.Mode().Perm()&0o750)
+	})
+
+	t.Run("link raw file", func(t *testing.T) {
+		runner := newCmdRunner(t)
+		servePath := filepath.FromSlash("../../testdata/downloadables/rawfile/foo")
+		ts := serveFile(t, servePath, "/foo/foo", "")
+		depURL := ts.URL + "/foo/foo"
+		runner.writeConfig(&bindown.Config{
+			URLChecksums: map[string]string{
+				depURL: "f044ff8b6007c74bcc1b5a5c92776e5d49d6014f5ff2d551fab115c17f48ac41",
+			},
+			Dependencies: map[string]*bindown.Dependency{
+				"foo": {
+					URL:  &depURL,
+					Link: ptr(true),
+				},
+			},
+		})
+		result := runner.run("install", "foo")
+		require.Equal(t, 0, result.exitVal)
+		wantBin := filepath.Join(runner.tmpDir, "bin", "foo")
+		require.FileExists(t, wantBin)
+		stat, err := os.Lstat(wantBin)
+		require.NoError(t, err)
+		require.EqualValues(t, os.FileMode(0o750), stat.Mode().Perm()&0o750)
+		require.True(t, stat.Mode()&os.ModeSymlink != 0)
 	})
 
 	t.Run("bin in root", func(t *testing.T) {

--- a/cmd/bindown/cli_test.go
+++ b/cmd/bindown/cli_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -529,7 +528,6 @@ func Test_installCmd(t *testing.T) {
 			},
 		})
 		result := runner.run("install", "foo")
-		fmt.Println(result.stdErr.String())
 		require.Equal(t, 1, result.exitVal)
 		require.True(t, strings.HasPrefix(result.stdErr.String(), `cmd: error: checksum mismatch in downloaded file`))
 		require.NoFileExists(t, filepath.Join(runner.tmpDir, "bin", "foo"))

--- a/cmd/bindown/completion_test.go
+++ b/cmd/bindown/completion_test.go
@@ -20,7 +20,7 @@ func Test_findConfigFileForCompletion(t *testing.T) {
 		})
 
 		t.Run("exists", func(t *testing.T) {
-			dir := t.TempDir()
+			dir := tmpDir(t)
 			configFile := filepath.Join(dir, "bindown.yml")
 			err := os.WriteFile(configFile, nil, 0o600)
 			require.NoError(t, err)
@@ -65,7 +65,7 @@ func Test_completionConfig(t *testing.T) {
 	})
 
 	t.Run("empty config file", func(t *testing.T) {
-		dir := t.TempDir()
+		dir := tmpDir(t)
 		configFile := filepath.Join(dir, "bindown.yml")
 		err := os.WriteFile(configFile, []byte("no valid yaml here"), 0o600)
 		require.NoError(t, err)
@@ -112,7 +112,7 @@ func setConfigFileEnvVar(t *testing.T, file string) {
 func createConfigFile(t *testing.T, sourceFile string) string {
 	t.Helper()
 	sourceFile = filepath.Join("..", "..", "testdata", "configs", sourceFile)
-	dir := t.TempDir()
+	dir := tmpDir(t)
 	dest := filepath.Join(dir, "bindown.config")
 	copyFile(t, sourceFile, dest)
 	return dest

--- a/cmd/bindown/completion_test.go
+++ b/cmd/bindown/completion_test.go
@@ -20,7 +20,7 @@ func Test_findConfigFileForCompletion(t *testing.T) {
 		})
 
 		t.Run("exists", func(t *testing.T) {
-			dir := tmpDir(t)
+			dir := t.TempDir()
 			configFile := filepath.Join(dir, "bindown.yml")
 			err := os.WriteFile(configFile, nil, 0o600)
 			require.NoError(t, err)
@@ -65,7 +65,7 @@ func Test_completionConfig(t *testing.T) {
 	})
 
 	t.Run("empty config file", func(t *testing.T) {
-		dir := tmpDir(t)
+		dir := t.TempDir()
 		configFile := filepath.Join(dir, "bindown.yml")
 		err := os.WriteFile(configFile, []byte("no valid yaml here"), 0o600)
 		require.NoError(t, err)
@@ -112,7 +112,7 @@ func setConfigFileEnvVar(t *testing.T, file string) {
 func createConfigFile(t *testing.T, sourceFile string) string {
 	t.Helper()
 	sourceFile = filepath.Join("..", "..", "testdata", "configs", sourceFile)
-	dir := tmpDir(t)
+	dir := t.TempDir()
 	dest := filepath.Join(dir, "bindown.config")
 	copyFile(t, sourceFile, dest)
 	return dest

--- a/cmd/bindown/template_test.go
+++ b/cmd/bindown/template_test.go
@@ -170,7 +170,7 @@ templates:
   tmpl2:
     url: bar
 `
-	srcFile := filepath.Join(tmpDir(t), "template-source.yaml")
+	srcFile := filepath.Join(t.TempDir(), "template-source.yaml")
 	err := os.WriteFile(srcFile, []byte(remoteConfig), 0o600)
 	require.NoError(t, err)
 
@@ -238,7 +238,7 @@ templates:
   tmpl2:
     url: bar
 `
-	srcFile := filepath.Join(tmpDir(t), "template-source.yaml")
+	srcFile := filepath.Join(t.TempDir(), "template-source.yaml")
 	err := os.WriteFile(srcFile, []byte(remoteConfig), 0o600)
 	require.NoError(t, err)
 	server := serveFile(t, srcFile, "/template-source.yaml", "")

--- a/cmd/bindown/template_test.go
+++ b/cmd/bindown/template_test.go
@@ -170,7 +170,7 @@ templates:
   tmpl2:
     url: bar
 `
-	srcFile := filepath.Join(t.TempDir(), "template-source.yaml")
+	srcFile := filepath.Join(tmpDir(t), "template-source.yaml")
 	err := os.WriteFile(srcFile, []byte(remoteConfig), 0o600)
 	require.NoError(t, err)
 
@@ -238,7 +238,7 @@ templates:
   tmpl2:
     url: bar
 `
-	srcFile := filepath.Join(t.TempDir(), "template-source.yaml")
+	srcFile := filepath.Join(tmpDir(t), "template-source.yaml")
 	err := os.WriteFile(srcFile, []byte(remoteConfig), 0o600)
 	require.NoError(t, err)
 	server := serveFile(t, srcFile, "/template-source.yaml", "")

--- a/cmd/bindown/testutil_test.go
+++ b/cmd/bindown/testutil_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/willabides/bindown/v3"
-	"github.com/willabides/bindown/v3/internal/cache"
 )
 
 type cmdRunner struct {
@@ -30,18 +29,18 @@ func newCmdRunner(t testing.TB) *cmdRunner {
 	t.Helper()
 	dir := t.TempDir()
 	cacheDir := filepath.Join(dir, "cache")
-	t.Cleanup(func() {
-		t.Helper()
-		assert.NoError(t, cache.RemoveRoot(filepath.Join(cacheDir, "downloads")))
-		assert.NoError(t, cache.RemoveRoot(filepath.Join(cacheDir, "extracts")))
-	})
 	configfile := filepath.Join(dir, ".bindown.yaml")
-	return &cmdRunner{
+	runner := &cmdRunner{
 		t:          t,
 		cache:      cacheDir,
 		configFile: configfile,
 		tmpDir:     dir,
 	}
+	t.Cleanup(func() {
+		// ignore errors because it fails on test with missing or invalid config files
+		runner.run("cache", "clear")
+	})
+	return runner
 }
 
 func (c *cmdRunner) run(commandLine ...string) *runCmdResult {

--- a/cmd/bindown/testutil_test.go
+++ b/cmd/bindown/testutil_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/fs"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -222,23 +221,4 @@ func testInDir(t testing.TB, dir string) {
 		assert.NoError(t, os.Chdir(orig))
 	})
 	assert.NoError(t, os.Chdir(dir))
-}
-
-func unsealDir(t testing.TB, dir string) {
-	_, err := os.Stat(dir)
-	if os.IsNotExist(err) {
-		return
-	}
-	assert.NoError(t, err)
-	err = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		info, err := d.Info()
-		if err != nil {
-			return err
-		}
-		return os.Chmod(path, info.Mode()|0o222)
-	})
-	assert.NoError(t, err)
 }

--- a/config.go
+++ b/config.go
@@ -362,7 +362,11 @@ func (c *Config) ClearCache() error {
 	if err != nil {
 		return err
 	}
-	return cache.RemoveRoot(c.extractsCache().Root)
+	err = cache.RemoveRoot(c.extractsCache().Root)
+	if err != nil {
+		return err
+	}
+	return os.RemoveAll(c.Cache)
 }
 
 // ConfigDownloadDependencyOpts options for Config.DownloadDependency

--- a/config.go
+++ b/config.go
@@ -357,6 +357,14 @@ func (c *Config) Validate(dependencies []string, systems []SystemInfo) (errOut e
 	return nil
 }
 
+func (c *Config) ClearCache() error {
+	err := cache.RemoveRoot(c.downloadsCache().Root)
+	if err != nil {
+		return err
+	}
+	return cache.RemoveRoot(c.extractsCache().Root)
+}
+
 // ConfigDownloadDependencyOpts options for Config.DownloadDependency
 type ConfigDownloadDependencyOpts struct {
 	TargetFile           string

--- a/config_test.go
+++ b/config_test.go
@@ -2,7 +2,6 @@ package bindown
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -443,9 +442,5 @@ func TestConfig_addChecksum(t *testing.T) {
 	require.NoError(t, err)
 	err = cfg.addChecksum("dut", newSystemInfo("testOS2", "foo"))
 	require.NoError(t, err)
-
-	b, err := yaml.Marshal(cfg)
-	require.NoError(t, err)
-	fmt.Println(string(b))
 	require.Equal(t, want, cfg)
 }

--- a/config_test.go
+++ b/config_test.go
@@ -201,7 +201,7 @@ func TestConfig_addTemplateFromSource(t *testing.T) {
 
 func TestConfig_InstallDependency(t *testing.T) {
 	t.Run("raw file", func(t *testing.T) {
-		dir := t.TempDir()
+		dir := tmpDir(t)
 		servePath := filepath.Join("testdata", "downloadables", filepath.FromSlash("rawfile/foo"))
 		ts := serveFile(t, servePath, "/foo/foo", "")
 		depURL := ts.URL + "/foo/foo"
@@ -232,7 +232,7 @@ func TestConfig_InstallDependency(t *testing.T) {
 	})
 
 	t.Run("bin in root", func(t *testing.T) {
-		dir := t.TempDir()
+		dir := tmpDir(t)
 		servePath := filepath.Join("testdata", "downloadables", "fooinroot.tar.gz")
 		ts := serveFile(t, servePath, "/foo/fooinroot.tar.gz", "")
 		depURL := ts.URL + "/foo/fooinroot.tar.gz"
@@ -263,7 +263,7 @@ func TestConfig_InstallDependency(t *testing.T) {
 	})
 
 	t.Run("wrong checksum", func(t *testing.T) {
-		dir := t.TempDir()
+		dir := tmpDir(t)
 		servePath := filepath.Join("testdata", "downloadables", "fooinroot.tar.gz")
 		ts := serveFile(t, servePath, "/foo/fooinroot.tar.gz", "")
 		depURL := ts.URL + "/foo/fooinroot.tar.gz"
@@ -303,23 +303,23 @@ func TestConfig_addChecksums(t *testing.T) {
 	cfg := &Config{
 		Dependencies: map[string]*Dependency{
 			"d1": {
-				URL: stringPtr(dl1),
+				URL: &dl1,
 				Overrides: []DependencyOverride{
 					{
-						Dependency:      Dependency{URL: stringPtr(dl2)},
+						Dependency:      Dependency{URL: &dl2},
 						OverrideMatcher: OverrideMatcher{"os": []string{"darwin"}},
 					},
 					{
-						Dependency:      Dependency{URL: stringPtr(dl5)},
+						Dependency:      Dependency{URL: &dl5},
 						OverrideMatcher: OverrideMatcher{"os": []string{"windows"}},
 					},
 				},
 			},
 			"d2": {
-				URL: stringPtr(dl3),
+				URL: &dl3,
 				Overrides: []DependencyOverride{
 					{
-						Dependency:      Dependency{URL: stringPtr(dl4)},
+						Dependency:      Dependency{URL: &dl4},
 						OverrideMatcher: OverrideMatcher{"os": []string{"darwin"}},
 					},
 				},
@@ -344,7 +344,7 @@ func TestConfig_BuildDependency(t *testing.T) {
 	cfg := &Config{
 		Dependencies: map[string]*Dependency{
 			"dut": {
-				URL: stringPtr("https://{{.os}}"),
+				URL: ptr("https://{{.os}}"),
 				Overrides: []DependencyOverride{
 					{
 						OverrideMatcher: OverrideMatcher{
@@ -352,7 +352,7 @@ func TestConfig_BuildDependency(t *testing.T) {
 							"os":   []string{"testOS"},
 						},
 						Dependency: Dependency{
-							URL: stringPtr("https://{{.os}}-{{.var1}}-{{.var2}}"),
+							URL: ptr("https://{{.os}}-{{.var1}}-{{.var2}}"),
 							Vars: map[string]string{
 								"var1": "overrideV1",
 								"var2": "overrideV2",
@@ -383,7 +383,7 @@ func TestConfig_addChecksum(t *testing.T) {
 	cfg := &Config{
 		Dependencies: map[string]*Dependency{
 			"dut": {
-				URL: stringPtr(dlURL),
+				URL: &dlURL,
 				Overrides: []DependencyOverride{
 					{
 						OverrideMatcher: OverrideMatcher{
@@ -391,7 +391,7 @@ func TestConfig_addChecksum(t *testing.T) {
 							"os":   []string{"testOS"},
 						},
 						Dependency: Dependency{
-							URL: stringPtr(dlURL2),
+							URL: &dlURL2,
 							Vars: map[string]string{
 								"var1": "overrideV1",
 								"var2": "overrideV2",
@@ -409,7 +409,7 @@ func TestConfig_addChecksum(t *testing.T) {
 	want := &Config{
 		Dependencies: map[string]*Dependency{
 			"dut": {
-				URL: stringPtr(dlURL),
+				URL: &dlURL,
 				Overrides: []DependencyOverride{
 					{
 						OverrideMatcher: OverrideMatcher{
@@ -417,7 +417,7 @@ func TestConfig_addChecksum(t *testing.T) {
 							"os":   []string{"testOS"},
 						},
 						Dependency: Dependency{
-							URL: stringPtr(dlURL2),
+							URL: &dlURL2,
 							Vars: map[string]string{
 								"var1": "overrideV1",
 								"var2": "overrideV2",

--- a/config_test.go
+++ b/config_test.go
@@ -201,7 +201,7 @@ func TestConfig_addTemplateFromSource(t *testing.T) {
 
 func TestConfig_InstallDependency(t *testing.T) {
 	t.Run("raw file", func(t *testing.T) {
-		dir := tmpDir(t)
+		dir := t.TempDir()
 		servePath := filepath.Join("testdata", "downloadables", filepath.FromSlash("rawfile/foo"))
 		ts := serveFile(t, servePath, "/foo/foo", "")
 		depURL := ts.URL + "/foo/foo"
@@ -220,6 +220,7 @@ func TestConfig_InstallDependency(t *testing.T) {
 				},
 			},
 		}
+		t.Cleanup(func() { require.NoError(t, config.ClearCache()) })
 		wantBin := filepath.Join(binDir, "foo")
 		gotPath, err := config.InstallDependency("foo", newSystemInfo("darwin", "amd64"), &ConfigInstallDependencyOpts{})
 		require.NoError(t, err)
@@ -232,7 +233,7 @@ func TestConfig_InstallDependency(t *testing.T) {
 	})
 
 	t.Run("bin in root", func(t *testing.T) {
-		dir := tmpDir(t)
+		dir := t.TempDir()
 		servePath := filepath.Join("testdata", "downloadables", "fooinroot.tar.gz")
 		ts := serveFile(t, servePath, "/foo/fooinroot.tar.gz", "")
 		depURL := ts.URL + "/foo/fooinroot.tar.gz"
@@ -251,6 +252,7 @@ func TestConfig_InstallDependency(t *testing.T) {
 				},
 			},
 		}
+		t.Cleanup(func() { require.NoError(t, config.ClearCache()) })
 		wantBin := filepath.Join(binDir, "foo")
 		gotPath, err := config.InstallDependency("foo", newSystemInfo("darwin", "amd64"), &ConfigInstallDependencyOpts{})
 		require.NoError(t, err)
@@ -263,7 +265,7 @@ func TestConfig_InstallDependency(t *testing.T) {
 	})
 
 	t.Run("wrong checksum", func(t *testing.T) {
-		dir := tmpDir(t)
+		dir := t.TempDir()
 		servePath := filepath.Join("testdata", "downloadables", "fooinroot.tar.gz")
 		ts := serveFile(t, servePath, "/foo/fooinroot.tar.gz", "")
 		depURL := ts.URL + "/foo/fooinroot.tar.gz"
@@ -282,6 +284,7 @@ func TestConfig_InstallDependency(t *testing.T) {
 				},
 			},
 		}
+		t.Cleanup(func() { require.NoError(t, config.ClearCache()) })
 		wantBin := filepath.Join(binDir, "foo")
 		_, err := config.InstallDependency("foo", newSystemInfo("darwin", "amd64"), &ConfigInstallDependencyOpts{})
 		require.Error(t, err)

--- a/dependency.go
+++ b/dependency.go
@@ -225,12 +225,11 @@ func (d *Dependency) applyOverrides(info SystemInfo, depth int) {
 	d.Overrides = nil
 }
 
-func linkBin(link, extractDir, archivePath string) error {
-	absExtractDir, err := filepath.Abs(extractDir)
+func linkBin(link, src string) error {
+	absSrc, err := filepath.Abs(src)
 	if err != nil {
 		return err
 	}
-	extractedBin := filepath.Join(absExtractDir, archivePath)
 	err = os.MkdirAll(filepath.Dir(link), 0o750)
 	if err != nil {
 		return err
@@ -246,12 +245,12 @@ func linkBin(link, extractDir, archivePath string) error {
 		return err
 	}
 
-	extractedBin, err = filepath.EvalSymlinks(extractedBin)
+	absSrc, err = filepath.EvalSymlinks(absSrc)
 	if err != nil {
 		return err
 	}
 
-	dst, err := filepath.Rel(linkDir, extractedBin)
+	dst, err := filepath.Rel(linkDir, absSrc)
 	if err != nil {
 		return err
 	}

--- a/docs/clihelp.txt
+++ b/docs/clihelp.txt
@@ -36,6 +36,7 @@ Commands:
   checksums add                  add checksums to the config file
   checksums prune                remove unnecessary checksums from the config file
   init                           create an empty config file
+  cache clear                    clear the cache
   version                        show bindown version
   install-completions            install shell completions
 

--- a/download.go
+++ b/download.go
@@ -1,0 +1,141 @@
+package bindown
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/willabides/bindown/v3/internal/cache"
+)
+
+func downloadDependency(
+	dep *builtDependency,
+	dlCache *cache.Cache,
+	trustCache, allowMissingChecksum, force bool,
+) (filename, key string, dir fs.FS, unlock func() error, errOut error) {
+	dlFile, err := urlFilename(dep.url)
+	if err != nil {
+		return "", "", nil, nil, err
+	}
+
+	var downloader func(dir string) error
+	checksum := dep.checksum
+	if checksum == "" {
+		if !allowMissingChecksum {
+			err = fmt.Errorf("no checksum configured for %s", dep.name)
+			return "", "", nil, nil, err
+		}
+		var tempDir string
+		tempDir, err = os.MkdirTemp("", "bindown")
+		if err != nil {
+			return "", "", nil, nil, err
+		}
+		defer deferErr(&errOut, func() error {
+			return os.RemoveAll(tempDir)
+		})
+		tempFile := filepath.Join(tempDir, dlFile)
+		checksum, err = getURLChecksum(dep.url, tempFile)
+		if err != nil {
+			return "", "", nil, nil, err
+		}
+		downloader = func(dir string) (dlErrOut error) {
+			return copyFile(tempFile, filepath.Join(dir, dlFile), nil)
+		}
+	} else {
+		downloader = func(dir string) error {
+			ok, dlErr := fileExistsWithChecksum(filepath.Join(dir, dlFile), checksum)
+			if dlErr != nil || ok {
+				return dlErr
+			}
+			gotSum, dlErr := downloadFile(filepath.Join(dir, dlFile), dep.url)
+			if dlErr != nil {
+				return dlErr
+			}
+			if checksum != gotSum {
+				return fmt.Errorf(`checksum mismatch in downloaded file %q 
+wanted: %s
+got: %s`, filename, checksum, gotSum)
+			}
+			return nil
+		}
+	}
+	key = cacheKey(checksum)
+	if force {
+		err = dlCache.Evict(key)
+		if err != nil {
+			return "", "", nil, nil, err
+		}
+	}
+
+	validator := func(dir fs.FS) error {
+		got, sumErr := fsFileChecksum(dir, dlFile)
+		if sumErr != nil {
+			return sumErr
+		}
+		if got != checksum {
+			return fmt.Errorf("expected checksum %s, got %s", checksum, got)
+		}
+		return nil
+	}
+	if trustCache && !force {
+		validator = nil
+	}
+
+	dir, unlock, err = dlCache.Dir(key, validator, downloader)
+	if err != nil {
+		return "", "", nil, nil, err
+	}
+	return dlFile, key, dir, unlock, nil
+}
+
+// downloadFile downloads the file at url to targetPath. It returns the checksum of the file.
+func downloadFile(targetPath, url string) (_ string, errOut error) {
+	hasher := sha256.New()
+	err := os.MkdirAll(filepath.Dir(targetPath), 0o750)
+	if err != nil {
+		return "", err
+	}
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer deferErr(&errOut, resp.Body.Close)
+	bodyReader := io.TeeReader(resp.Body, hasher)
+	if resp.StatusCode >= 300 {
+		return "", fmt.Errorf("failed downloading %s", url)
+	}
+	out, err := os.Create(targetPath)
+	if err != nil {
+		return "", err
+	}
+	defer deferErr(&errOut, out.Close)
+	_, err = io.Copy(out, bodyReader)
+	if err != nil {
+		return "", err
+	}
+	sum := hex.EncodeToString(hasher.Sum(nil))
+	return sum, nil
+}
+
+// getURLChecksum returns the checksum of the file at dlURL. If tempFile is specified
+// it will be used as the temporary file to download the file to and it will be the caller's
+// responsibility to clean it up. Otherwise, a temporary file will be created and cleaned up
+// automatically.
+func getURLChecksum(dlURL, tempFile string) (_ string, errOut error) {
+	if tempFile == "" {
+		downloadDir, err := os.MkdirTemp("", "bindown")
+		if err != nil {
+			return "", err
+		}
+		tempFile = filepath.Join(downloadDir, "download")
+		defer deferErr(&errOut, func() error {
+			return os.RemoveAll(downloadDir)
+		})
+	}
+	return downloadFile(tempFile, dlURL)
+}

--- a/extract.go
+++ b/extract.go
@@ -1,0 +1,88 @@
+package bindown
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/mholt/archiver/v3"
+	"github.com/willabides/bindown/v3/internal/cache"
+)
+
+func extractDependencyToCache(
+	archivePath, cacheDir, key string,
+	exCache *cache.Cache,
+	trustCache, force bool,
+) (outDir string, fsDir fs.FS, unlock func() error, errOut error) {
+	extractSumsDir := filepath.Join(cacheDir, ".extract_sums")
+	err := os.MkdirAll(extractSumsDir, 0o755)
+	if err != nil {
+		return "", nil, nil, err
+	}
+	extractSumFile := filepath.Join(extractSumsDir, key+".sum")
+
+	validator := func(dir fs.FS) error {
+		if trustCache {
+			return nil
+		}
+		wantSum, vErr := os.ReadFile(extractSumFile)
+		if vErr != nil {
+			return vErr
+		}
+		gotSum, vErr := fsDirectoryChecksum(dir)
+		if vErr != nil {
+			return vErr
+		}
+		if gotSum != string(wantSum) {
+			return fmt.Errorf("expected checksum %s, got %s", wantSum, gotSum)
+		}
+		return nil
+	}
+
+	extractor := func(dir string) error {
+		exErr := extract(archivePath, dir)
+		if exErr != nil {
+			return exErr
+		}
+		gotSum, exErr := fsDirectoryChecksum(os.DirFS(dir))
+		if exErr != nil {
+			return exErr
+		}
+		return os.WriteFile(extractSumFile, []byte(gotSum), 0o644)
+	}
+
+	if force {
+		err = exCache.Evict(key)
+		if err != nil {
+			return "", nil, nil, err
+		}
+	}
+	fsDir, unlock, err = exCache.Dir(key, validator, extractor)
+	if err != nil {
+		return "", nil, nil, err
+	}
+	outDir = filepath.Join(exCache.Root, key)
+	return outDir, fsDir, unlock, nil
+}
+
+// extract extracts an archive
+func extract(archivePath, extractDir string) error {
+	dlName := filepath.Base(archivePath)
+	downloadDir := filepath.Dir(archivePath)
+
+	err := os.RemoveAll(extractDir)
+	if err != nil {
+		return err
+	}
+	err = os.MkdirAll(extractDir, 0o750)
+	if err != nil {
+		return err
+	}
+	tarPath := filepath.Join(downloadDir, dlName)
+	_, err = archiver.ByExtension(dlName)
+	if err != nil {
+		return copyFile(tarPath, filepath.Join(extractDir, dlName), nil)
+	}
+	return archiver.Unarchive(tarPath, extractDir)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/willabides/bindown/v3
 
-go 1.18
+go 1.20
 
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
@@ -9,6 +9,7 @@ require (
 	github.com/mholt/archiver/v3 v3.5.1
 	github.com/posener/complete v1.2.3
 	github.com/qri-io/jsonschema v0.2.1
+	github.com/rogpeppe/go-internal v1.10.0
 	github.com/stretchr/testify v1.7.0
 	github.com/willabides/kongplete v0.3.0
 	golang.org/x/exp v0.0.0-20230321023759-10a507213a29

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/qri-io/jsonschema v0.2.1 h1:NNFoKms+kut6ABPf6xiKNM5214jzxAhDBrPHCJ97W
 github.com/qri-io/jsonschema v0.2.1/go.mod h1:g7DPkiOsK1xv6T/Ao5scXRkd+yTFygcANPBaaqW+VrI=
 github.com/riywo/loginshell v0.0.0-20200815045211-7d26008be1ab h1:ZjX6I48eZSFetPb41dHudEyVr5v953N15TsNZXlkcWY=
 github.com/riywo/loginshell v0.0.0-20200815045211-7d26008be1ab/go.mod h1:/PfPXh0EntGc3QAAyUaviy4S9tzy4Zp0e2ilq4voC6E=
+github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
+github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/install.go
+++ b/install.go
@@ -1,12 +1,11 @@
 package bindown
 
 import (
-	"io/fs"
 	"os"
 	"path/filepath"
 )
 
-func install(dep *builtDependency, fsDir fs.FS, targetPath, extractDir string) (string, error) {
+func install(dep *builtDependency, targetPath, extractDir string) (string, error) {
 	var binName string
 	if dep.BinName != nil {
 		binName = *dep.BinName
@@ -18,8 +17,9 @@ func install(dep *builtDependency, fsDir fs.FS, targetPath, extractDir string) (
 	if dep.ArchivePath != nil {
 		archivePath = filepath.FromSlash(*dep.ArchivePath)
 	}
+	extractBin := filepath.Join(extractDir, archivePath)
 	if dep.Link != nil && *dep.Link {
-		return targetPath, linkBin(targetPath, extractDir, archivePath)
+		return targetPath, linkBin(targetPath, extractBin)
 	}
 	if fileExists(targetPath) {
 		err := os.RemoveAll(targetPath)
@@ -31,9 +31,7 @@ func install(dep *builtDependency, fsDir fs.FS, targetPath, extractDir string) (
 	if err != nil {
 		return "", err
 	}
-	err = copyFile(archivePath, targetPath, &copyFileOpts{
-		srcFs: fsDir,
-	})
+	err = copyFile(extractBin, targetPath)
 	if err != nil {
 		return "", err
 	}

--- a/install.go
+++ b/install.go
@@ -1,0 +1,49 @@
+package bindown
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+func install(dep *builtDependency, fsDir fs.FS, targetPath, extractDir string) (string, error) {
+	var binName string
+	if dep.BinName != nil {
+		binName = *dep.BinName
+	}
+	if binName == "" {
+		binName = dep.name
+	}
+	archivePath := filepath.FromSlash(binName)
+	if dep.ArchivePath != nil {
+		archivePath = filepath.FromSlash(*dep.ArchivePath)
+	}
+	if dep.Link != nil && *dep.Link {
+		return targetPath, linkBin(targetPath, extractDir, archivePath)
+	}
+	if fileExists(targetPath) {
+		err := os.RemoveAll(targetPath)
+		if err != nil {
+			return "", err
+		}
+	}
+	err := os.MkdirAll(filepath.Dir(targetPath), 0o755)
+	if err != nil {
+		return "", err
+	}
+	err = copyFile(archivePath, targetPath, &copyFileOpts{
+		srcFs: fsDir,
+	})
+	if err != nil {
+		return "", err
+	}
+	targetStat, err := os.Stat(targetPath)
+	if err != nil {
+		return "", err
+	}
+	err = os.Chmod(targetPath, targetStat.Mode()|0o750)
+	if err != nil {
+		return "", err
+	}
+	return targetPath, nil
+}

--- a/internal/build-bootstrapper/build.go
+++ b/internal/build-bootstrapper/build.go
@@ -17,14 +17,12 @@ var assets embed.FS
 
 func execBindown(repoRoot string, arg ...string) error {
 	bindownPath := filepath.FromSlash("bin/bootstrapped/bindown")
-	//nolint:gosec // subprocess launch with variable
 	makeCmd := exec.Command("make", bindownPath)
 	makeCmd.Dir = repoRoot
 	err := makeCmd.Run()
 	if err != nil {
 		return err
 	}
-	//nolint:gosec // subprocess launch with variable
 	bindownCmd := exec.Command(bindownPath, arg...)
 	bindownCmd.Dir = repoRoot
 	return bindownCmd.Run()
@@ -110,14 +108,12 @@ func build(tag, repoRoot string) (_ string, errOut error) {
 	if err != nil {
 		return "", err
 	}
-	//nolint:gosec // subprocess launch with variable
 	shfmtCmd := exec.Command(filepath.Join(repoRoot, "bin", "shfmt"), "-i", "2", "-ci", "-sr", "-")
 	shfmtCmd.Stdin = &tmplOut
 	formatted, err := shfmtCmd.Output()
 	if err != nil {
 		return "", err
 	}
-	//nolint:gosec // subprocess launch with variable
 	shellcheckCmd := exec.Command(filepath.Join(repoRoot, "bin", "shellcheck"), "--shell", "sh", "-")
 	shellcheckCmd.Stdin = bytes.NewReader(formatted)
 	err = shellcheckCmd.Run()

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,0 +1,258 @@
+package cache
+
+import (
+	"errors"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/rogpeppe/go-internal/lockedfile"
+)
+
+type (
+	populateFunc func(string) error
+	validateFunc func(fs.FS) error
+)
+
+type Cache struct {
+	Root string
+}
+
+// Dir returns a fs.FS for the given key, populating the cache if necessary.
+// The returned fs.FS is valid until unlock is called. After that the contents may change unexpectedly.
+func (c *Cache) Dir(key string, validate validateFunc, populate populateFunc) (_ fs.FS, unlock func() error, _ error) {
+	var err error
+	key, err = parseKey(key)
+	if err != nil {
+		return nil, nil, err
+	}
+	lock, err := c.rLock(key)
+	if err != nil {
+		return nil, nil, err
+	}
+	dir := filepath.Join(c.Root, key)
+	fsDir := os.DirFS(dir)
+	validateErr := validateDir(dir, validate)
+	if validateErr == nil {
+		return fsDir, lock.Close, nil
+	}
+	if populate == nil {
+		return nil, nil, errors.Join(validateErr, lock.Close())
+	}
+	err = lock.Close()
+	if err != nil {
+		return nil, nil, err
+	}
+	err = c.populate(key, validate, populate)
+	if err != nil {
+		return nil, nil, err
+	}
+	lock, err = c.rLock(key)
+	if err != nil {
+		return nil, nil, err
+	}
+	err = validateDir(dir, validate)
+	if err != nil {
+		return nil, nil, err
+	}
+	return fsDir, lock.Close, nil
+}
+
+// Evict removes acquires a write lock and removes the cache entry for the given key.
+func (c *Cache) Evict(key string) (errOut error) {
+	var err error
+	key, err = parseKey(key)
+	if err != nil {
+		return err
+	}
+	lock, err := c.lock(key)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		errOut = errors.Join(errOut, lock.Close())
+	}()
+	dir := filepath.Join(c.Root, key)
+	info, err := os.Stat(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if !info.IsDir() {
+		return errors.New("not a directory")
+	}
+	err = os.RemoveAll(dir)
+	if err != nil {
+		return err
+	}
+	return os.Remove(c.lockfile(key))
+}
+
+func (c *Cache) lockfile(key string) string {
+	return filepath.Join(c.locksDir(), key)
+}
+
+func (c *Cache) locksDir() string {
+	return filepath.Join(c.Root, ".locks")
+}
+
+func (c *Cache) lock(key string) (io.Closer, error) {
+	err := os.MkdirAll(c.locksDir(), 0o777)
+	if err != nil {
+		return nil, err
+	}
+	file, err := lockedfile.OpenFile(c.lockfile(key), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o666)
+	if err != nil {
+		return nil, err
+	}
+	dir := filepath.Join(c.Root, key)
+	err = unsealDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	return &writeLock{
+		file: file,
+		dir:  dir,
+	}, nil
+}
+
+type writeLock struct {
+	file *lockedfile.File
+	dir  string
+}
+
+func (l *writeLock) Close() (errOut error) {
+	sealDir(l.dir)
+	return l.file.Close()
+}
+
+func (c *Cache) rLock(key string) (io.Closer, error) {
+	err := os.MkdirAll(c.locksDir(), 0o777)
+	if err != nil {
+		return nil, err
+	}
+	lockfile := c.lockfile(key)
+	_, err = os.Stat(lockfile)
+	if os.IsNotExist(err) {
+		err = os.WriteFile(lockfile, nil, 0o666)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return lockedfile.OpenFile(lockfile, os.O_RDONLY, 0)
+}
+
+func (c *Cache) populate(key string, validate validateFunc, populate populateFunc) (errOut error) {
+	lock, err := c.lock(key)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		errOut = errors.Join(errOut, lock.Close())
+	}()
+	dir := filepath.Join(c.Root, key)
+	info, err := os.Stat(dir)
+	if os.IsNotExist(err) {
+		err = os.MkdirAll(dir, 0o777)
+		if err != nil {
+			return err
+		}
+		return populate(dir)
+	}
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return errors.New("not a directory")
+	}
+	if validateDir(dir, validate) == nil {
+		return nil
+	}
+	err = os.RemoveAll(dir)
+	if err != nil {
+		return err
+	}
+	err = os.MkdirAll(dir, 0o777)
+	if err != nil {
+		return err
+	}
+	return populate(dir)
+}
+
+func validateDir(dir string, validate validateFunc) error {
+	info, err := os.Stat(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return errors.New("entry does not exist")
+		}
+		return err
+	}
+	if !info.IsDir() {
+		return errors.New("not a directory")
+	}
+	if validate == nil {
+		return nil
+	}
+	return validate(os.DirFS(dir))
+}
+
+func parseKey(key string) (string, error) {
+	key = filepath.FromSlash(key)
+	// key must be a valid file name without path separators
+	if key != filepath.Base(key) {
+		return "", errors.New("invalid key")
+	}
+	// reserve dot files for internal use
+	if strings.HasPrefix(key, ".") {
+		return "", errors.New("invalid key")
+	}
+	return key, nil
+}
+
+// sealDir removes the write permission from a directory and all its contents.
+// This is best-effort, and will not fail if the permissions cannot be changed.
+//
+//nolint:errcheck // this is best-effort
+func sealDir(dir string) {
+	var files []string
+	_ = filepath.WalkDir(dir, func(path string, _ fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		files = append(files, path)
+		return nil
+	})
+	// go backwards to remove write permissions from subdirectories first
+	for i := len(files) - 1; i >= 0; i-- {
+		f := files[i]
+		stat, err := os.Lstat(f)
+		if err != nil {
+			continue
+		}
+		if stat.Mode()&0o222 == 0 {
+			continue
+		}
+		_ = os.Chmod(f, stat.Mode()&^0o222)
+	}
+}
+
+func unsealDir(dir string) error {
+	_, err := os.Stat(dir)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		return os.Chmod(path, info.Mode()|0o222)
+	})
+}

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -1,0 +1,275 @@
+package cache
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCache_Dir(t *testing.T) {
+	t.Run("reads existing file", func(t *testing.T) {
+		cache := &Cache{Root: tmpDir(t)}
+		testFile := filepath.Join(cache.Root, "foo", "foo.txt")
+		mustWriteFile(t, testFile, "bar")
+		dir, unlock, err := cache.Dir("foo", fooValidator, nil)
+		require.NoError(t, err)
+		assertFsFile(t, dir, "foo.txt", "bar")
+		mustUnlock(t, unlock)
+	})
+
+	t.Run("reads existing file with no validator", func(t *testing.T) {
+		cache := &Cache{Root: tmpDir(t)}
+		testFile := filepath.Join(cache.Root, "foo", "foo.txt")
+		mustWriteFile(t, testFile, "bar")
+		dir, unlock, err := cache.Dir("foo", nil, nil)
+		require.NoError(t, err)
+		assertFsFile(t, dir, "foo.txt", "bar")
+		mustUnlock(t, unlock)
+	})
+
+	t.Run("populates cache", func(t *testing.T) {
+		cache := &Cache{Root: tmpDir(t)}
+		dir, unlock, err := cache.Dir("foo", fooValidator, fooPopulator)
+		require.NoError(t, err)
+		assertFsFile(t, dir, "foo.txt", "bar")
+		mustUnlock(t, unlock)
+	})
+
+	t.Run("re-populates cache when invalid", func(t *testing.T) {
+		cache := &Cache{Root: tmpDir(t)}
+		testFile := filepath.Join(cache.Root, "foo", "foo.txt")
+		mustWriteFile(t, testFile, "invalid")
+		extraFile := filepath.Join(cache.Root, "foo", "extra.txt")
+		mustWriteFile(t, extraFile, "extra")
+		dir, unlock, err := cache.Dir("foo", fooValidator, fooPopulator)
+		require.NoError(t, err)
+		assertFsFile(t, dir, "foo.txt", "bar")
+		assertFsFileNotExist(t, dir, "extra.txt")
+		mustUnlock(t, unlock)
+	})
+
+	t.Run("errors when populator is nil on new cache", func(t *testing.T) {
+		cache := &Cache{Root: tmpDir(t)}
+		_, _, err := cache.Dir("foo", fooValidator, nil)
+		require.EqualError(t, err, "entry does not exist")
+	})
+
+	t.Run("errors when populator is nil on invalid cache", func(t *testing.T) {
+		cache := &Cache{Root: tmpDir(t)}
+		testFile := filepath.Join(cache.Root, "foo", "foo.txt")
+		mustWriteFile(t, testFile, "invalid")
+		_, _, err := cache.Dir("foo", fooValidator, nil)
+		require.EqualError(t, err, "invalid entry")
+	})
+
+	t.Run("errors when populated content is invalid", func(t *testing.T) {
+		cache := &Cache{Root: tmpDir(t)}
+		_, _, err := cache.Dir("foo", fooValidator, func(dir string) error {
+			return nil
+		})
+		require.EqualError(t, err, "open foo.txt: no such file or directory")
+	})
+
+	t.Run("errors when populator returns error", func(t *testing.T) {
+		cache := &Cache{Root: tmpDir(t)}
+		_, _, err := cache.Dir("foo", fooValidator, func(dir string) error {
+			return assert.AnError
+		})
+		require.EqualError(t, err, assert.AnError.Error())
+	})
+
+	t.Run("errors when dir is a file", func(t *testing.T) {
+		cache := &Cache{Root: tmpDir(t)}
+		testFile := filepath.Join(cache.Root, "foo.txt")
+		mustWriteFile(t, testFile, "bar")
+		_, _, err := cache.Dir("foo.txt", nil, nil)
+		require.EqualError(t, err, "not a directory")
+	})
+
+	t.Run("multiple read locks", func(t *testing.T) {
+		cache := &Cache{Root: tmpDir(t)}
+		dir1, unlock1, err := cache.Dir("foo", fooValidator, fooPopulator)
+		require.NoError(t, err)
+		dir2, unlock2, err := cache.Dir("foo", fooValidator, fooPopulator)
+		require.NoError(t, err)
+		assertFsFile(t, dir1, "foo.txt", "bar")
+		assertFsFile(t, dir2, "foo.txt", "bar")
+		mustUnlock(t, unlock1)
+		mustUnlock(t, unlock2)
+	})
+
+	t.Run("release then re-acquire lock", func(t *testing.T) {
+		cache := &Cache{Root: tmpDir(t)}
+		dir1, unlock1, err := cache.Dir("foo", fooValidator, fooPopulator)
+		require.NoError(t, err)
+		assertFsFile(t, dir1, "foo.txt", "bar")
+		mustUnlock(t, unlock1)
+		dir2, unlock2, err := cache.Dir("foo", fooValidator, fooPopulator)
+		require.NoError(t, err)
+		assertFsFile(t, dir2, "foo.txt", "bar")
+		mustUnlock(t, unlock2)
+	})
+
+	t.Run("invalid keys", func(t *testing.T) {
+		cache := &Cache{Root: tmpDir(t)}
+		keys := []string{
+			"/foo",
+			"../foo",
+			"foo/../bar",
+			"foo/",
+			"",
+			".foo",
+		}
+		for _, key := range keys {
+			t.Run(key, func(t *testing.T) {
+				_, _, err := cache.Dir(key, fooValidator, fooPopulator)
+				require.EqualError(t, err, "invalid key")
+			})
+		}
+	})
+
+	t.Run("directory is replaced by a file after read lock released", func(t *testing.T) {
+		cache := &Cache{Root: tmpDir(t)}
+
+		testDir := filepath.Join(cache.Root, "foo")
+		testFile := filepath.Join(testDir, "foo.txt")
+		mustWriteFile(t, testFile, "bar")
+		validate := func(dir fs.FS) error {
+			err := os.RemoveAll(testDir)
+			assert.NoError(t, err)
+			mustWriteFile(t, testDir, "bar")
+			return assert.AnError
+		}
+		_, _, err := cache.Dir("foo", validate, fooPopulator)
+		require.EqualError(t, err, "not a directory")
+	})
+
+	t.Run("entry becomes valid after read lock released", func(t *testing.T) {
+		cache := &Cache{Root: tmpDir(t)}
+		testFile := filepath.Join(cache.Root, "foo", "foo.txt")
+		mustWriteFile(t, testFile, "bar")
+		validateCallCount := 0
+		validate := func(dir fs.FS) error {
+			validateCallCount++
+			if validateCallCount == 1 {
+				return assert.AnError
+			}
+			return fooValidator(dir)
+		}
+		dir, unlock, err := cache.Dir("foo", validate, fooPopulator)
+		require.NoError(t, err)
+		assertFsFile(t, dir, "foo.txt", "bar")
+		mustUnlock(t, unlock)
+	})
+}
+
+func TestCache_Evict(t *testing.T) {
+	t.Run("no-op for non-existent key", func(t *testing.T) {
+		cache := &Cache{Root: tmpDir(t)}
+		err := cache.Evict("foo")
+		require.NoError(t, err)
+	})
+
+	t.Run("evicts existing key", func(t *testing.T) {
+		cache := &Cache{Root: tmpDir(t)}
+		dir, unlock, err := cache.Dir("foo", fooValidator, fooPopulator)
+		require.NoError(t, err)
+		assertFsFile(t, dir, "foo.txt", "bar")
+		mustUnlock(t, unlock)
+		err = cache.Evict("foo")
+		require.NoError(t, err)
+		// validate it's gone by trying to open it with no populator
+		_, _, err = cache.Dir("foo", nil, nil)
+		require.EqualError(t, err, "entry does not exist")
+	})
+
+	t.Run("errors when key is a file", func(t *testing.T) {
+		cache := &Cache{Root: tmpDir(t)}
+		testFile := filepath.Join(cache.Root, "foo.txt")
+		mustWriteFile(t, testFile, "bar")
+		err := cache.Evict("foo.txt")
+		require.EqualError(t, err, "not a directory")
+	})
+
+	t.Run("invalid keys", func(t *testing.T) {
+		cache := &Cache{Root: tmpDir(t)}
+		keys := []string{
+			"/foo",
+			"../foo",
+			"foo/../bar",
+			"foo/",
+			"",
+			".foo",
+		}
+		for _, key := range keys {
+			t.Run(key, func(t *testing.T) {
+				err := cache.Evict(key)
+				require.EqualError(t, err, "invalid key")
+			})
+		}
+	})
+}
+
+var (
+	fooValidator = fileValidator("foo.txt", "bar")
+	fooPopulator = filePopulator("foo.txt", "bar")
+)
+
+func fileValidator(filename, want string) validateFunc {
+	return func(dir fs.FS) error {
+		b, err := fs.ReadFile(dir, filename)
+		if err != nil {
+			return err
+		}
+		if string(b) != want {
+			return fmt.Errorf("invalid entry")
+		}
+		return nil
+	}
+}
+
+func filePopulator(filename, content string) populateFunc {
+	return func(dir string) error {
+		n := filepath.Join(dir, filename)
+		return os.WriteFile(n, []byte(content), 0o666)
+	}
+}
+
+func assertFsFile(t testing.TB, dir fs.FS, name, content string) {
+	t.Helper()
+	b, err := fs.ReadFile(dir, name)
+	assert.NoError(t, err)
+	assert.Equal(t, content, string(b))
+}
+
+func assertFsFileNotExist(t testing.TB, dir fs.FS, name string) {
+	t.Helper()
+	_, err := dir.Open(name)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func mustWriteFile(t testing.TB, file, content string) {
+	t.Helper()
+	err := os.MkdirAll(filepath.Dir(file), 0o777)
+	require.NoError(t, err)
+	err = os.WriteFile(file, []byte(content), 0o666)
+	require.NoError(t, err)
+}
+
+func mustUnlock(t testing.TB, unlock func() error) {
+	t.Helper()
+	require.NoError(t, unlock())
+}
+
+func tmpDir(t testing.TB) string {
+	dir := t.TempDir()
+	t.Cleanup(func() {
+		assert.NoError(t, unsealDir(dir))
+	})
+	return dir
+}

--- a/testutil_test.go
+++ b/testutil_test.go
@@ -1,14 +1,10 @@
 package bindown
 
 import (
-	"io/fs"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"path/filepath"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
 // fooChecksum is the checksum of downloadablesPath("foo.tar.gz")
@@ -40,18 +36,4 @@ func newSystemInfo(goOs, goArch string) SystemInfo {
 
 func ptr[T any](val T) *T {
 	return &val
-}
-
-func tmpDir(t testing.TB) string {
-	dir := t.TempDir()
-	t.Cleanup(func() {
-		err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
-			if err != nil {
-				return err
-			}
-			return os.Chmod(path, 0o777)
-		})
-		assert.NoError(t, err)
-	})
-	return dir
 }

--- a/testutil_test.go
+++ b/testutil_test.go
@@ -27,10 +27,10 @@ func serveFile(t *testing.T, file, path, query string) *httptest.Server {
 	return ts
 }
 
-func newSystemInfo(goOs, goArch string) SystemInfo {
+func newSystemInfo(os, arch string) SystemInfo {
 	return SystemInfo{
-		OS:   goOs,
-		Arch: goArch,
+		OS:   os,
+		Arch: arch,
 	}
 }
 

--- a/util.go
+++ b/util.go
@@ -26,7 +26,6 @@ func executeTemplate(tmplString, goos, arch string, vars map[string]string) (str
 	maps.Copy(tmplData, vars)
 	tmpl, err := template.New("").Option("missingkey=error").Parse(tmplString)
 	if err != nil {
-		fmt.Println(err.Error())
 		return "", fmt.Errorf("%q is not a valid template", tmplString)
 	}
 	var buf bytes.Buffer

--- a/util_test.go
+++ b/util_test.go
@@ -1,8 +1,6 @@
 package bindown
 
 import (
-	"crypto/sha256"
-	"hash/fnv"
 	"os"
 	"path/filepath"
 	"testing"
@@ -55,23 +53,6 @@ func Test_fileExistsWithChecksum(t *testing.T) {
 	})
 }
 
-func Test_fileChecksum(t *testing.T) {
-	t.Run("success", func(t *testing.T) {
-		file := filepath.Join(t.TempDir(), "myfile")
-		require.NoError(t, copyFile(filepath.Join("testdata", "downloadables", "foo.tar.gz"), file, nil))
-		got, err := fileChecksum(file)
-		require.NoError(t, err)
-		require.Equal(t, fooChecksum, got)
-	})
-
-	t.Run("doesn't exist", func(t *testing.T) {
-		file := filepath.Join(t.TempDir(), "myfile")
-		got, err := fileChecksum(file)
-		require.Error(t, err)
-		require.Empty(t, got)
-	})
-}
-
 func Test_directoryChecksum(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		got, err := directoryChecksum(filepath.Join("testdata", "directoryChecksum"))
@@ -79,14 +60,6 @@ func Test_directoryChecksum(t *testing.T) {
 		// This should only change when the contents of testdata/directoryChecksum change.
 		require.Equal(t, "0eb72a7b3c1e286a", got)
 	})
-}
-
-func Test_hexHash(t *testing.T) {
-	require.Equal(t, "dcb27518fed9d577", hexHash(fnv.New64a(), []byte("foo")))
-	require.Equal(t, "85944171f73967e8", hexHash(fnv.New64a(), []byte("foo"), []byte("bar")))
-	content, err := os.ReadFile(filepath.Join("testdata", "downloadables", "foo.tar.gz"))
-	require.NoError(t, err)
-	require.Equal(t, fooChecksum, hexHash(sha256.New(), content))
 }
 
 func Test_copyFile(t *testing.T) {

--- a/util_test.go
+++ b/util_test.go
@@ -30,7 +30,7 @@ func TestExecuteTemplate(t *testing.T) {
 func Test_fileExistsWithChecksum(t *testing.T) {
 	t.Run("exists", func(t *testing.T) {
 		file := filepath.Join(t.TempDir(), "myfile")
-		require.NoError(t, copyFile(filepath.Join("testdata", "downloadables", "foo.tar.gz"), file, nil))
+		require.NoError(t, copyFile(filepath.Join("testdata", "downloadables", "foo.tar.gz"), file))
 		got, err := fileExistsWithChecksum(file, fooChecksum)
 		require.NoError(t, err)
 		require.True(t, got)
@@ -39,7 +39,7 @@ func Test_fileExistsWithChecksum(t *testing.T) {
 	t.Run("wrong checksum", func(t *testing.T) {
 		file := filepath.Join(t.TempDir(), "myfile")
 		checksum := "0000000000000000000000000000000000000000000000000000000000000000"
-		require.NoError(t, copyFile(filepath.Join("testdata", "downloadables", "foo.tar.gz"), file, nil))
+		require.NoError(t, copyFile(filepath.Join("testdata", "downloadables", "foo.tar.gz"), file))
 		got, err := fileExistsWithChecksum(file, checksum)
 		require.NoError(t, err)
 		require.False(t, got)
@@ -67,7 +67,7 @@ func Test_copyFile(t *testing.T) {
 		dir := t.TempDir()
 		src := filepath.Join(dir, "file1")
 		dst := filepath.Join(dir, "file2")
-		err := copyFile(src, dst, nil)
+		err := copyFile(src, dst)
 		require.Error(t, err)
 	})
 
@@ -77,7 +77,7 @@ func Test_copyFile(t *testing.T) {
 		dst := filepath.Join(dir, "file2")
 		err := os.Mkdir(src, 0o750)
 		require.NoError(t, err)
-		err = copyFile(src, dst, nil)
+		err = copyFile(src, dst)
 		require.Error(t, err)
 	})
 
@@ -87,7 +87,7 @@ func Test_copyFile(t *testing.T) {
 		dst := filepath.Join(dir, "file2")
 		content := []byte("foo")
 		require.NoError(t, os.WriteFile(src, content, 0o600))
-		err := copyFile(src, dst, nil)
+		err := copyFile(src, dst)
 		require.NoError(t, err)
 
 		got, err := os.ReadFile(dst)
@@ -101,7 +101,7 @@ func Test_copyFile(t *testing.T) {
 		dst := filepath.Join(dir, "dst", "file2")
 		content := []byte("foo")
 		require.NoError(t, os.WriteFile(src, content, 0o600))
-		err := copyFile(src, dst, nil)
+		err := copyFile(src, dst)
 		require.Error(t, err)
 	})
 
@@ -112,7 +112,7 @@ func Test_copyFile(t *testing.T) {
 		content := []byte("foo")
 		require.NoError(t, os.WriteFile(src, content, 0o600))
 		require.NoError(t, os.WriteFile(dst, []byte("bar"), 0o600))
-		err := copyFile(src, dst, nil)
+		err := copyFile(src, dst)
 		require.NoError(t, err)
 		got, err := os.ReadFile(dst)
 		require.NoError(t, err)


### PR DESCRIPTION
Uses lockedfile to get a lock on a directory before reading or writing.

Adds a `bindown cache clear` command.

The new cache has a ReadOnly option that isn't currently being used. I changed my mind on it at the last minute because even with `bindown cache clear` it is annoying to require sudo to `rm -rf` the cache dir.

In the future I want to put the default cache in `$XDG_CACHE_HOME` and share it between bindown configs. When we have that it will make sense to use a read-only cache.
