### PR TITLE
update default cache dir

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,13 +98,13 @@ jobs:
             ${{ steps.setup-go.outputs.GOMODCACHE }}
           key: ${{ runner.os }}-go-release-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-go-release
-      - uses: WillAbides/release-train@v3.2.1
+      - uses: WillAbides/release-train@v3.3.0
         id: release-train
         with:
           create-release: true
           release-refs: main
           pre-tag-hook: |
-            set -e
+            set -ex
             script/check-module-version "$(go list -m)" "$RELEASE_TAG"
             script/bindown install goreleaser
             git tag "$RELEASE_TAG"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
       matrix:
         platform:
           - ubuntu-22.04
-          - macos-13
-          - windows-2022
+#          - macos-13
+#          - windows-2022
       fail-fast: false
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
           create-release: true
           release-refs: main
           pre-tag-hook: |
-            set -ex
+            set -e
             script/check-module-version "$(go list -m)" "$RELEASE_TAG"
             script/bindown install goreleaser
             git tag "$RELEASE_TAG"

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/mholt/archiver/v4 v4.0.0-alpha.8
 	github.com/posener/complete v1.2.3
 	github.com/rogpeppe/go-internal v1.10.0
+	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.0
 	github.com/stretchr/testify v1.7.1
 	github.com/willabides/kongplete v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -167,6 +167,8 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd/go.mod h1:hPqNNc0+uJM6H+SuU8sEs5K5IQeKccPqeSjfgcKGgPk=
+github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 h1:OkMGxebDjyw0ULyrTYWeN0UNCCkmCWfjPnIA2W6oviI=
+github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06/go.mod h1:+ePHsJ1keEjQtpvf9HHw0f4ZeJ0TLRsxhunSI2hYJSs=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.0 h1:uIkTLo0AGRc8l7h5l9r+GcYi9qfVPt6lD4/bhmzfiKo=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.0/go.mod h1:FKdcjfQW6rpZSnxxUvEA5H/cDPdvJ/SZJQLWWXWGrZ0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/internal/bindown/config.go
+++ b/internal/bindown/config.go
@@ -681,18 +681,22 @@ func findCacheDir(cfgDir string) (string, error) {
 	if err == nil && info.IsDir() {
 		return bindownDir, nil
 	}
-	// if .cache is ignored by .gitignore, use it
+	// if .bindown is in .gitignore, use it
+	ig, err := dirIsGitIgnored(bindownDir)
+	if err != nil {
+		return "", err
+	}
+	if ig {
+		return bindownDir, nil
+	}
+	// if .cache is in .gitignore, use it
 	cacheDir := filepath.Join(cfgDir, ".cache")
-	// When a dir is ignored with a trailing slash, we need to check if a file in that dir is ignored.
-	for _, dir := range []string{cacheDir, filepath.Join(cacheDir, "downloads")} {
-		var ignored bool
-		ignored, err = fileIsGitignored(dir)
-		if err != nil {
-			return "", err
-		}
-		if ignored {
-			return cacheDir, nil
-		}
+	ig, err = dirIsGitIgnored(cacheDir)
+	if err != nil {
+		return "", err
+	}
+	if ig {
+		return cacheDir, nil
 	}
 	// default to .bindown
 	return bindownDir, nil

--- a/internal/bindown/util.go
+++ b/internal/bindown/util.go
@@ -230,6 +230,17 @@ func Unique[V comparable](vals, buf []V) []V {
 	return buf
 }
 
+func dirIsGitIgnored(dir string) (bool, error) {
+	ig, err := fileIsGitignored(dir)
+	if err != nil {
+		return false, err
+	}
+	if ig {
+		return true, nil
+	}
+	return fileIsGitignored(filepath.Join(dir, "x"))
+}
+
 // fileIsGitignored returns true if the file is ignored by a .gitignore file in the same directory or any parent
 // directory from the same git repo.
 func fileIsGitignored(filename string) (bool, error) {


### PR DESCRIPTION
Updates the default cache dir to be `.bindown` unless `.bindown` doesn't exist and `.cache` is in `.gitignore`.
