### PR TITLE
split out wrap command

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ Commands:
   download                            download a dependency but don't extract or install it
   extract                             download and extract a dependency but don't install it
   install                             download, extract and install a dependency
+  wrap                                create a wrapper script for a dependency
   format                              formats the config file
   dependency list                     list configured dependencies
   dependency add                      add a template-based dependency

--- a/cmd/bindown/dependency.go
+++ b/cmd/bindown/dependency.go
@@ -132,7 +132,7 @@ func (c *dependencyListCmd) Run(ctx *runContext) error {
 	if err != nil {
 		return err
 	}
-	fmt.Fprintln(ctx.stdout, strings.Join(allDependencies(cfg), "\n"))
+	fmt.Fprintln(ctx.stdout, strings.Join(cfg.DependencyNames(), "\n"))
 	return nil
 }
 

--- a/cmd/bindown/testutil_test.go
+++ b/cmd/bindown/testutil_test.go
@@ -70,7 +70,7 @@ func (c *cmdRunner) run(commandLine ...string) *runCmdResult {
 		&runOpts{
 			stdin:   simpleFileReader{c.stdin},
 			stdout:  SimpleFileWriter{&result.stdOut},
-			stderr:  &result.stdErr,
+			stderr:  SimpleFileWriter{&result.stdErr},
 			cmdName: "cmd",
 			exitHandler: func(i int) {
 				result.exited = true
@@ -102,7 +102,7 @@ func (c *cmdRunner) runExpect(expectFunc func(*expect.Console), commandLine ...s
 			&runOpts{
 				stdin:   console.Tty(),
 				stdout:  console.Tty(),
-				stderr:  &result.stdErr,
+				stderr:  console.Tty(),
 				cmdName: "cmd",
 				exitHandler: func(i int) {
 					result.exited = true

--- a/docs/clihelp.txt
+++ b/docs/clihelp.txt
@@ -13,6 +13,7 @@ Commands:
   download                            download a dependency but don't extract or install it
   extract                             download and extract a dependency but don't install it
   install                             download, extract and install a dependency
+  wrap                                create a wrapper script for a dependency
   format                              formats the config file
   dependency list                     list configured dependencies
   dependency add                      add a template-based dependency


### PR DESCRIPTION
Deprecates `--wrapper` on `bindown install` and replaces it with `bindown wrap`.