### PR TITLE
Fix panic running with no args

### DIFF
--- a/cmd/bindown/cli.go
+++ b/cmd/bindown/cli.go
@@ -68,6 +68,9 @@ type rootCmd struct {
 }
 
 func (r *rootCmd) BeforeApply(k *kong.Context) error {
+	if k == nil || k.Selected() == nil {
+		return nil
+	}
 	// set dependency positional to optional for install, wrap, download and extract.
 	// We do this because we want to allow --all to be equivalent to specifying all
 	// dependencies but want the help output to indicate that a dependency is required.

--- a/cmd/bindown/dependency_test.go
+++ b/cmd/bindown/dependency_test.go
@@ -403,6 +403,7 @@ dependencies:
 		runner := newCmdRunner(t)
 		srcFile := filepath.Join(runner.tmpDir, "template-source.yaml")
 		runner.writeConfigYaml(fmt.Sprintf(`
+systems: ["linux/amd64", "darwin/amd64"]
 url_checksums:
   foo-linux-amd64-1.2.3: deadbeef
   foo-darwin-amd64-1.2.3: deadbeef
@@ -436,6 +437,7 @@ dependencies:
 		runner := newCmdRunner(t)
 		srcFile := filepath.Join(runner.tmpDir, "template-source.yaml")
 		runner.writeConfigYaml(fmt.Sprintf(`
+systems: ["linux/amd64", "darwin/amd64"]
 url_checksums:
   foo-linux-amd64-1.2.3: deadbeef
   foo-darwin-amd64-1.2.3: deadbeef


### PR DESCRIPTION
Running bindown with no args was panicking.

Also fix tests running on darwin/arm64.